### PR TITLE
Add .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine. 
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Orbs are reusable packages of CircleCI configuration that you may share across projects, enabling you to create encapsulated, parameterized commands, jobs, and executors that can be used across multiple projects.
+orbs:
+  android: circleci/android@1.0.3
+
+jobs:
+  # Below is the definition of your job to build and test your app, you can rename and customize it as you want.
+  build-and-test:  
+    # These next lines define the Android machine image executor: https://circleci.com/docs/2.0/executor-types/
+    executor:
+      name: android/android-machine
+
+    steps:
+      # Checkout the code as the first step.
+      - checkout
+
+      # The next step will run the unit tests
+      - android/run-tests:
+          test-command: ./gradlew lint testDebug --continue
+
+      # Then start the emulator and run the Instrumentation tests!
+      - android/start-emulator-and-run-tests:
+          test-command: ./gradlew connectedDebugAndroidTest
+          system-image: system-images;android-25;google_apis;x86
+
+      # And finally run the release build
+      - run:
+          name: Assemble release build
+          command: |
+            ./gradlew assembleRelease    
+
+workflows:
+  # Below is the definition of your workflow.
+  # Inside the workflow, you provide the jobs you want to run, e.g this workflow runs the build-and-test job above.
+  # CircleCI will run this workflow on every commit.
+  # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows
+  sample: 
+    jobs:
+      - build-and-test


### PR DESCRIPTION
version: 2.1 # Set the CI version.

# We use orbs to provide some common ruby and node tasks and shorten our config.
# Learn more about orbs: https://circleci.com/orbs/
orbs:
  ruby: circleci/ruby@0.1.2
  node: circleci/node@1.1.6
  md-proofer: hubci/md-proofer@0.1


# Yaml References enable us to DRY out our config by sharing variables across multiple jobs.
# In this case, we are commonly using the "workspaces" feature to share
# build artifacts and files across jobs. For example, we build our Javascript
# persist it to a workspace to be made available when the Jekyll site builds.
references:
  workspace_root: &workspace_root
    /tmp/workspace
  attach_workspace: &attach_workspace
    attach_workspace:
      at: *workspace_root


# Several steps in this config use the same, specialized ruby-caching steps.
# Commands can be used to extract a common set of steps into a reusable-block.
# In this case, whenever you see `- ruby-deps` as a "step" in the config below,
# It is executing a command to restore_cache, install deps if needed, and save_cache.
commands:
  install-shared-assets:
     description: "Updates the shared-code between outer and docs."
     steps:
       - run:
           name: update submodules
           command: git submodule update --init src-shared
  ruby-deps:
    description: "Runs specialized Ruby cache steps."
    parameters:
      dir:
        description: |
          The directory relative to the root of the repo to run bundle for.
          Leave empty for root directory.
        type: string
        default: ""
    steps:
      - restore_cache:
          key: circleci-docs-v1-{{ .Branch }}-<< parameters.dir >>-{{ checksum "Gemfile.lock" }}
      - run:
          name: Install Ruby dependencies
          command:
            |
            if [[ "<< parameters.dir >>" != "" ]]; then
              cd << parameters.dir >>
            fi
            bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
      - save_cache:
          key: circleci-docs-v1-{{ .Branch }}-<< parameters.dir >>-{{ checksum "Gemfile.lock" }}
          paths:
            - "vendor/bundle"
            - "<< parameters.dir >>/vendor/bundle"
  set-jekyll-basename:
    description: Set JEKYLL_BASENAME env var and persist in $BASH_ENV
    steps:
      - run:
          name: Populate JEKYLL_BASENAME env var
          command: |
            if [ ${CIRCLE_BRANCH} = master -o ${CIRCLE_BRANCH} = main ]; then
              echo "export JEKYLL_BASENAME=docs" >> $BASH_ENV;
            else
              echo "export JEKYLL_BASENAME=${CIRCLE_BRANCH}" >> $BASH_ENV;
            fi

# Workflows orchestrate a set of jobs to be run;
# the jobs for this pipeline are # configured below
workflows:

  build-deploy:
    jobs:
      - js_build
      - build_server_pdfs:
          filters:
            branches:
              only: /server\/.*/
      - build_api_docs
      - build:
          requires:
            - js_build
            - build_server_pdfs
            - build_api_docs
      - reindex-search:
          requires:
            - build
          filters:
            branches:
              only: master
      - deploy-preview:
          requires:
            - build
          filters:
            branches:
              only: /.*-preview/
      - deploy:
          requires:
            - build
          filters:
            branches:
              only: master
  # We run a nightly build for running build/maintenance tasks
  # such as pulling in docker image tags or automating our api documentation
  nightly-build:
    triggers:
      - schedule:
          cron: "0 8 * * *"
          filters:
            branches:
              only: master
    jobs:
      - js_build
      - build_api_docs
      - build:
          requires:
            - js_build
            - build_api_docs
      - deploy:
          requires:
            - build


jobs:
  js_build: # this job is responsible for building Javascript assets and making them available for the "build" job
    executor: # we specify our executor to use the node orb.
      name: node/default
      tag: '8.11.1'
    steps:
      - *attach_workspace
      - checkout # get the code from GitHub
      - install-shared-assets
      - node/with-cache: # An orb command for steps to run in-between restoring and saving a cache.
          cache-key: "package-lock.json"
          cache-version: &npm-cache-version v9 # Gets cache version from project environment variable (E.g v1)
          steps:
            - run: npm install
      - run:
          name: "Prepare JS assets" # Compile our final, production-ready JavaScript.
          command: npm run webpack-prod
      - run:
          name: "Persist JS assets" # Move our JS into our workspace.
          command: |
            set -exu
            mkdir -p /tmp/workspace/js
            mv jekyll/assets/js/*.bundle.js /tmp/workspace/js/
      - persist_to_workspace: # store the built files into the workspace for other jobs.
          root: *workspace_root
          paths:
            - js



  build_server_pdfs: # this job builds server-related pdf documentation, persisting it to the workspace as well.
    docker:
      - image: asciidoctor/docker-asciidoctor
    steps:
      - *attach_workspace
      - checkout
      - run:
          name: Build PDFs for Server
          command: ./scripts/build_pdfs_asciidoc.sh
      - store_artifacts:
          path: release/tmp/

  build_api_docs: # a job to manage building our api documentation and persisting it to the workspace
    executor:
      name: ruby/default
      tag: '2.7.2-node-browsers'
    steps:
      - checkout
      - install-shared-assets
      - *attach_workspace
      - run:
          name: "Create landing folder for API doc output"
          command: |
            mkdir -p /tmp/workspace/api/v1
            mkdir -p /tmp/workspace/api/v2
      - ruby-deps:
          dir: src-api
      - restore_cache:
          key: circleci-docs-v2-{{ .Branch }}-{{ checksum "src-api/package-lock.json"}}
      - run:
          name: Install Node dependencies
          command: cd src-api; npm install
      - save_cache:
          key: circleci-docs-v2-{{ .Branch }}-{{ checksum "src-api/package-lock.json"}}
          paths:
            - src-api/node_modules
      - run:
          name: Build API 1.x documentation with Slate
          command: ./scripts/build_api_docs.sh -v1
      - run:
          name: Build API 2.x documentation with Widdershins and Slate
          command: ./scripts/build_api_docs.sh -v2
      - persist_to_workspace:
          root: *workspace_root
          paths:
            - api

  # The Main "Build" job. It pulls in assets from previous jobs (the built api docs, pdfs and javascript)
  # and puts everything in its place for a Jekyll build.
  build:
    executor:
      name: ruby/default
      tag: '2.7.2-node-browsers'
    resource_class: medium+
    working_directory: ~/circleci-docs
    environment:
      JEKYLL_ENV: production
      JOB_RESULTS_PATH: run-results
    steps:
      - checkout
      - install-shared-assets
      - *attach_workspace
      - md-proofer/install:
          version: "0.3.0"
      - run:
          name: "Test Markdown Files"
          command: md-proofer lint jekyll/_cci2/ jekyll/_api/ jekyll/_cci1/
      - run:
          name: Install dependecies for pronto gem
          command: |
            sudo apt-get update
            sudo apt-get install cmake pkg-config
      - ruby-deps
      - node/with-cache: # An orb command for steps to run in-between restoring and saving a cache.
          cache-key: "package-lock.json"
          cache-version: *npm-cache-version # Gets cache version from project environment variable (E.g v1)
          steps:
            - run: npm install
      - run:
          name: Run markdownlint with pronto
          command: bundle exec pronto run -f github_pr -c origin/master
      - run:
          name: Create results directory
          command: mkdir -p $JOB_RESULTS_PATH
      - run:
          name: "Manage Data Files We'll Need"
          command: ./scripts/pull-docker-image-tags.sh
      - run:
          name: Restore Previous Job Assets (Javascript, API docs) to Jekyll directory.
          command: |
            set -exu
            mkdir -p /tmp/workspace/js
            mv /tmp/workspace/js/* jekyll/assets/js/
            mkdir -p /tmp/workspace/api
            cp -r /tmp/workspace/api/ jekyll/_api/
            # remove unusued /api folder.
            rm -rf jekyll/_api/api
            mkdir -p /tmp/workspace/pdfs
            cp -r /tmp/workspace/api/* jekyll/_api/
      - run: sudo apt-get update; sudo apt-get --yes install nkf
      - run:
          name: Shim untranslated Japanese pages
          command: ./scripts/shim-translation.sh jekyll/_cci2 jekyll/_cci2_ja
      - set-jekyll-basename
      - run:
          name: Build the Jekyll site
          command: bundle exec rake build
      - run:
          name: Workaround to pass htmlproofer for docs where baseurl (/docs) is hardcoded
          command: |
            if [ ! ${JEKYLL_BASENAME} = "docs" ]; then
              cd jekyll/_site
              ln -s ${JEKYLL_BASENAME} docs
            fi
      ### NOTE: we are ignoring some files in the HTML proofer as it fails on pending translated docs.
      - run:
          name: Test with HTMLproofer
          command: |
            bundle exec rake test
      - run:
          name: compress jekyll output
          command: |
            tar -zcvf circleci-docs.tar.gz jekyll/_site/
      - store_artifacts: # stores the built files of the Jekyll site
          path: circleci-docs.tar.gz
          destination: circleci-docs
      - store_artifacts: # stores build log output.
          path: run-results/
          destination: run-results
      - persist_to_workspace:
          root: ~/circleci-docs/jekyll/
          paths:
            - _site/*

  reindex-search:
    executor:
      name: ruby/default
      tag: '2.7.2-node-browsers'
    working_directory: ~/circleci-docs
    environment:
      JEKYLL_ENV: production
    steps:
      - checkout
      - install-shared-assets
      - *attach_workspace
      - restore_cache:
          key: circleci-docs-{{ .Branch }}-{{ checksum "Gemfile.lock" }}
      - ruby-deps
      - run:
          name: Update Algolia Index
          command: |
            ALGOLIA_API_KEY=$ALGOLIA_PRIVATE_KEY bundle exec jekyll algolia --source jekyll --config jekyll/_config.yml
  deploy:
    docker:
      - image: cibuilds/aws:1.16.185
    steps:
      - attach_workspace:
          at: ./generated-site
      - set-jekyll-basename
      - run:
          name: Deploy to S3 if tests pass and branch is Master
          command: aws s3 sync generated-site/_site/${JEKYLL_BASENAME} s3://circle-production-static-site/${JEKYLL_BASENAME}/ --delete

  deploy-preview:
    docker:
      - image: cibuilds/aws:1.16.185
    steps:
      - attach_workspace:
          at: ./generated-site
      - set-jekyll-basename
      - run:
          name: Deploy preview version
          command: aws s3 sync generated-site/_site/${JEKYLL_BASENAME} s3://circleci-doc-preview/${JEKYLL_BASENAME}/ --delete
      - run:
          name: Preview deployment URL
          command: echo "Preview is deployed at http://circleci-doc-preview.s3-website-us-east-1.amazonaws.com/${JEKYLL_BASENAME}"
